### PR TITLE
[bugfix] Support other platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,27 @@ platforms:
       extra_vars:
         ansible_python_interpreter: '/usr/local/bin/python'
 
+  - name: openbsd-6.0-amd64
+    driver:
+      box: trombik/ansible-openbsd-6.0-amd64
+      box_check_update: false
+    driver_config:
+      ssh:
+        shell: '/bin/sh'
+    provisioner:
+      extra_vars:
+        ansible_python_interpreter: '/usr/local/bin/python'
+
+  - name: ubuntu-16.04-amd64
+    driver:
+      box: trombik/ansible-ubuntu-16.04-amd64
+      box_check_update: false
+
+  - name: centos-7.3-x86_64
+    driver:
+      box: trombik/ansible-centos-7.3-x86_64
+      box_check_update: false
+
 suites:
   - name: default
     provisioner:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ None
 | `x509_certificate_validate_command_secret` | dict of command to validate secret key (see below) | `{"openssl"=>"openssl rsa -check -in %s"}` |
 | `x509_certificate_validate_command_public` | dict of command to validate public key (see below) | `{"openssl"=>"openssl x509 -noout -in %s"}` |
 | `x509_certificate` | keys to manage (see below) | `[]` |
-| `x509_certificate_disable_log` | disable logging of sensitive data during the play if `yes`. note that the log will display the value of `x509_certificate`, including secret key, if `no` | `yes` |
+| `x509_certificate_debug_log` | enable logging of sensitive data during the play if `yes`. note that the log will display the value of `x509_certificate`, including secret key, if `yes` | `no` |
 
 ## `x509_certificate_validate_command_secret`
 
@@ -75,8 +75,8 @@ None
   roles:
     - ansible-role-x509-certificate
   vars:
-    # XXX NEVER set this variable to `no` unless you know what you are doing.
-    x509_certificate_disable_log: no
+    # XXX NEVER set this variable to `yes` unless you know what you are doing.
+    x509_certificate_debug_log: yes
 
     x509_certificate_additional_packages:
       - quagga

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ None
 | `x509_certificate_validate_command_secret` | dict of command to validate secret key (see below) | `{"openssl"=>"openssl rsa -check -in %s"}` |
 | `x509_certificate_validate_command_public` | dict of command to validate public key (see below) | `{"openssl"=>"openssl x509 -noout -in %s"}` |
 | `x509_certificate` | keys to manage (see below) | `[]` |
+| `x509_certificate_disable_log` | disable logging of sensitive data during the play if `yes`. note that the log will display the value of `x509_certificate`, including secret key, if `no` | `yes` |
 
 ## `x509_certificate_validate_command_secret`
 
@@ -74,8 +75,11 @@ None
   roles:
     - ansible-role-x509-certificate
   vars:
+    # XXX NEVER set this variable to `no` unless you know what you are doing.
+    x509_certificate_disable_log: no
+
     x509_certificate_additional_packages:
-      - postfix
+      - quagga
     x509_certificate:
       - name: foo
         state: present
@@ -105,8 +109,8 @@ None
         state: present
         public:
           path: /usr/local/etc/ssl/bar/bar.pub
-          owner: www
-          group: www
+          owner: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
+          group: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
           mode: "0644"
           key: |
             -----BEGIN CERTIFICATE-----
@@ -131,8 +135,8 @@ None
             -----END CERTIFICATE-----
         secret:
           path: /usr/local/etc/ssl/bar/bar.key
-          owner: www
-          group: www
+          owner: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
+          group: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
           key: |
             -----BEGIN RSA PRIVATE KEY-----
             MIIEowIBAAKCAQEA2fZ3dYrKBhnh+DhW0Opqc5ZXaONvC6hGEh+Bu34cyzCnWLCK
@@ -161,12 +165,12 @@ None
             DZERGGX2hN9r7xahxZwnIguKQzBr6CTYBSWGvGYCHJKSLKn9Yb6OAJEN1epmXdlx
             kPF7nY8Cs8V8LYiuuDp9UMLRc90AmF87rqUrY5YP2zw6iNNvUBKs
             -----END RSA PRIVATE KEY-----
-      - name: postfix
+      - name: quagga
         state: present
         public:
-          path: /usr/local/etc/postfix/certs/postfix.pem
-          owner: postfix
-          group: mail
+          path: "{% if ansible_os_family == 'FreeBSD' %}/usr/local{% endif %}/etc/quagga/certs/quagga.pem"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
           key: |
             -----BEGIN CERTIFICATE-----
             MIIDOjCCAiICCQDaGChPypIR9jANBgkqhkiG9w0BAQUFADBfMQswCQYDVQQGEwJB
@@ -189,9 +193,9 @@ None
             7IVZsbStnhJrawX31DQ=
             -----END CERTIFICATE-----
         secret:
-          path: /usr/local/etc/postfix/certs/postfix.key
-          owner: postfix
-          group: mail
+          path: "{% if ansible_os_family == 'FreeBSD' %}/usr/local{% endif %}/etc/quagga/certs/quagga.key"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
           mode: "0440"
           key: |
             -----BEGIN RSA PRIVATE KEY-----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ x509_certificate_validate_command_secret:
 x509_certificate_validate_command_public:
   openssl: openssl x509 -noout -in %s
 x509_certificate: []
+x509_certificate_disable_log: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ x509_certificate_validate_command_secret:
 x509_certificate_validate_command_public:
   openssl: openssl x509 -noout -in %s
 x509_certificate: []
-x509_certificate_disable_log: yes
+x509_certificate_debug_log: no

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install x509_certificate_packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_packages }}"
+
+- name: Install x509_certificate_additional_packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_additional_packages }}"

--- a/tasks/install-OpenBSD.yml
+++ b/tasks/install-OpenBSD.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install x509_certificate_packages
+  openbsd_pkg:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_packages }}"
+
+- name: Install x509_certificate_additional_packages
+  openbsd_pkg:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_additional_packages }}"

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install x509_certificate_packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_packages }}"
+
+- name: Install x509_certificate_additional_packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ x509_certificate_additional_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,11 @@
 
 - set_fact:
     x509_certificate_present: "{{ x509_certificate | selectattr('state', 'match', '^present$') | list }}"
+  no_log: "{{ x509_certificate_disable_log }}"
 
 - set_fact:
     x509_certificate_absent: "{{ x509_certificate | selectattr('state', 'match', '^absent$') | list }}"
+  no_log: "{{ x509_certificate_disable_log }}"
 
 - name: Create x509_certificate_dir
   file:
@@ -18,12 +20,14 @@
     owner: "{{ x509_certificate_default_owner }}"
     group: "{{ x509_certificate_default_group }}"
     state: directory
+  no_log: "{{ x509_certificate_disable_log }}"
 
 - name: Create directories for pub keys
   file:
     path: "{{ item.public.path | dirname }}"
     mode: 0755
     state: directory
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'path' in item.public"
@@ -34,6 +38,7 @@
     path: "{{ item.secret.path | dirname }}"
     mode: 0755
     state: directory
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'secret' in item"
@@ -48,6 +53,7 @@
     group: "{{ item.public.group | default(x509_certificate_default_group) }}"
     mode: "{{ item.public.mode | default(0444) }}"
     validate: "{{ x509_certificate_validate_command_public[x509_certificate_validate_command] }}"
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'public' in item"
@@ -60,8 +66,8 @@
     group: "{{ item.secret.group | default(x509_certificate_default_group) }}"
     mode: "{{ item.secret.mode | default(0400) }}"
     validate: "{{ x509_certificate_validate_command_secret[x509_certificate_validate_command] }}"
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_present }}"
-  no_log: yes
   when:
     - "'secret' in item"
 
@@ -69,6 +75,7 @@
   file:
     path: "{{ item.public.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
     state: absent
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_absent }}"
   when:
     - "'public' in item"
@@ -77,7 +84,7 @@
   file:
     path: "{{ item.secret.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
     state: absent
+  no_log: "{{ x509_certificate_disable_log }}"
   with_items: "{{ x509_certificate_absent }}"
-  no_log: yes
   when:
     - "'secret' in item"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - set_fact:
     x509_certificate_present: "{{ x509_certificate | selectattr('state', 'match', '^present$') | list }}"
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
 
 - set_fact:
     x509_certificate_absent: "{{ x509_certificate | selectattr('state', 'match', '^absent$') | list }}"
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
 
 - name: Create x509_certificate_dir
   file:
@@ -20,14 +20,14 @@
     owner: "{{ x509_certificate_default_owner }}"
     group: "{{ x509_certificate_default_group }}"
     state: directory
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
 
 - name: Create directories for pub keys
   file:
     path: "{{ item.public.path | dirname }}"
     mode: 0755
     state: directory
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'path' in item.public"
@@ -38,7 +38,7 @@
     path: "{{ item.secret.path | dirname }}"
     mode: 0755
     state: directory
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'secret' in item"
@@ -53,7 +53,7 @@
     group: "{{ item.public.group | default(x509_certificate_default_group) }}"
     mode: "{{ item.public.mode | default(0444) }}"
     validate: "{{ x509_certificate_validate_command_public[x509_certificate_validate_command] }}"
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'public' in item"
@@ -66,7 +66,7 @@
     group: "{{ item.secret.group | default(x509_certificate_default_group) }}"
     mode: "{{ item.secret.mode | default(0400) }}"
     validate: "{{ x509_certificate_validate_command_secret[x509_certificate_validate_command] }}"
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_present }}"
   when:
     - "'secret' in item"
@@ -75,7 +75,7 @@
   file:
     path: "{{ item.public.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
     state: absent
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"
   when:
     - "'public' in item"
@@ -84,7 +84,7 @@
   file:
     path: "{{ item.secret.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
     state: absent
-  no_log: "{{ x509_certificate_disable_log }}"
+  no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"
   when:
     - "'secret' in item"

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -2,8 +2,11 @@
   roles:
     - ansible-role-x509-certificate
   vars:
+    # XXX NEVER set this variable to `no` unless you know what you are doing.
+    x509_certificate_disable_log: no
+
     x509_certificate_additional_packages:
-      - postfix
+      - quagga
     x509_certificate:
       - name: foo
         state: present
@@ -33,8 +36,8 @@
         state: present
         public:
           path: /usr/local/etc/ssl/bar/bar.pub
-          owner: www
-          group: www
+          owner: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
+          group: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
           mode: "0644"
           key: |
             -----BEGIN CERTIFICATE-----
@@ -59,8 +62,8 @@
             -----END CERTIFICATE-----
         secret:
           path: /usr/local/etc/ssl/bar/bar.key
-          owner: www
-          group: www
+          owner: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
+          group: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}www{% elif ansible_os_family == 'RedHat' %}ftp{% else %}www-data{% endif %}"
           key: |
             -----BEGIN RSA PRIVATE KEY-----
             MIIEowIBAAKCAQEA2fZ3dYrKBhnh+DhW0Opqc5ZXaONvC6hGEh+Bu34cyzCnWLCK
@@ -89,12 +92,12 @@
             DZERGGX2hN9r7xahxZwnIguKQzBr6CTYBSWGvGYCHJKSLKn9Yb6OAJEN1epmXdlx
             kPF7nY8Cs8V8LYiuuDp9UMLRc90AmF87rqUrY5YP2zw6iNNvUBKs
             -----END RSA PRIVATE KEY-----
-      - name: postfix
+      - name: quagga
         state: present
         public:
-          path: /usr/local/etc/postfix/certs/postfix.pem
-          owner: postfix
-          group: mail
+          path: "{% if ansible_os_family == 'FreeBSD' %}/usr/local{% endif %}/etc/quagga/certs/quagga.pem"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
           key: |
             -----BEGIN CERTIFICATE-----
             MIIDOjCCAiICCQDaGChPypIR9jANBgkqhkiG9w0BAQUFADBfMQswCQYDVQQGEwJB
@@ -117,9 +120,9 @@
             7IVZsbStnhJrawX31DQ=
             -----END CERTIFICATE-----
         secret:
-          path: /usr/local/etc/postfix/certs/postfix.key
-          owner: postfix
-          group: mail
+          path: "{% if ansible_os_family == 'FreeBSD' %}/usr/local{% endif %}/etc/quagga/certs/quagga.key"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_quagga{% else %}quagga{% endif %}"
           mode: "0440"
           key: |
             -----BEGIN RSA PRIVATE KEY-----

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -2,8 +2,8 @@
   roles:
     - ansible-role-x509-certificate
   vars:
-    # XXX NEVER set this variable to `no` unless you know what you are doing.
-    x509_certificate_disable_log: no
+    # XXX NEVER set this variable to `yes` unless you know what you are doing.
+    x509_certificate_debug_log: yes
 
     x509_certificate_additional_packages:
       - quagga

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,5 @@
+__x509_certificate_dir: /etc/ssl
+__x509_certificate_packages:
+  - openssl
+__x509_certificate_default_owner: root
+__x509_certificate_default_group: root

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,4 @@
+__x509_certificate_dir: /etc/ssl
+__x509_certificate_packages: []
+__x509_certificate_default_owner: root
+__x509_certificate_default_group: wheel

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,5 @@
+__x509_certificate_dir: /etc/ssl
+__x509_certificate_packages:
+  - openssl
+__x509_certificate_default_owner: root
+__x509_certificate_default_group: root


### PR DESCRIPTION
also:

* use `quagga` instead of `postfix`
* always use `no_log` when `x509_certificate`, and its variants, is used
  in tasks
* introduce `x509_certificate_disable_log` for debugging